### PR TITLE
Unregistered claims must be (encodable) records

### DIFF
--- a/src/Node/GenericRecord.purs
+++ b/src/Node/GenericRecord.purs
@@ -1,0 +1,18 @@
+module GenericRecord where
+
+import Foreign.Generic.Class (class DecodeRecord, class EncodeRecord)
+import Prim.RowList (class RowToList)
+
+class (EncodeRecord r l, RowToList r l) <= Encodable r l
+
+instance encodableInstance ::
+  ( EncodeRecord r l, RowToList r l
+  ) =>
+  Encodable r l
+
+class (DecodeRecord r l, RowToList r l) <= Decodable r l
+
+instance decodableInstance ::
+  ( DecodeRecord r l, RowToList r l
+  ) =>
+  Decodable r l

--- a/src/Node/Jwt.purs
+++ b/src/Node/Jwt.purs
@@ -5,6 +5,7 @@ module Node.Jwt
   , verify
   ) where
 
+import Types
 import Control.Monad.Except (runExcept)
 import Control.Promise (Promise, toAffE)
 import Data.Bifunctor (lmap)
@@ -18,15 +19,15 @@ import Data.Traversable (traverse)
 import Effect.Aff (Aff)
 import Effect.Uncurried (EffectFn3, runEffectFn3)
 import Foreign (ForeignError, readNullOrUndefined, readString, renderForeignError)
-import Foreign.Generic (class Decode, class Encode, F, Foreign)
+import Foreign.Generic (F, Foreign)
 import Foreign.Generic (decode) as Generic
 import Foreign.Index ((!))
 import Options as Options
 import Prelude (bind, map, pure, ($), (<$>), (<*>), (<>), (>>=))
-import Types
+import GenericRecord (class Decodable, class Encodable)
 
 -- Extract JWT claims from any foreign value
-claims :: forall a. Decode a => Foreign -> Either (NonEmptyList ForeignError) (Claims a)
+claims :: forall r l. Decodable r l => Foreign -> Either (NonEmptyList ForeignError) (Claims r)
 claims token =
   runExcept do
     iat <- token ! "payload" ! "iat" >>= readNullOrUndefined >>= traverse Generic.decode
@@ -40,7 +41,7 @@ claims token =
     iss <- token ! "payload" ! "iss" >>= readNullOrUndefined >>= traverse readString
     sub <- token ! "payload" ! "sub" >>= readNullOrUndefined >>= traverse readString
     jti <- token ! "payload" ! "jti" >>= readNullOrUndefined >>= traverse readString
-    (unregistered :: Maybe a) <- token ! "payload" ! "unregistered" >>= readNullOrUndefined >>= traverse Generic.decode
+    (unregistered :: Maybe (Record r)) <- token ! "payload" ! "unregistered" >>= readNullOrUndefined >>= traverse Generic.decode
     pure { iat, nbf, exp, aud: unwrap <$> aud, iss, sub, jti, unregistered }
 
 -- Extract JWT headers from any foreign value
@@ -55,7 +56,7 @@ headers token =
 
 foreign import _sign :: EffectFn3 Foreign String Foreign (Promise String)
 
-sign :: forall a. Encode a => Secret -> JOSEHeaders -> Claims a -> Aff String
+sign :: forall r l. Encodable r l => Secret -> JOSEHeaders -> Claims r -> Aff String
 sign (Secret secret) { typ, cty, alg, kid } { iss, sub, aud, exp, nbf, iat, jti, unregistered } =
   toAffE
     $ runEffectFn3 _sign payloadOptions secret
@@ -91,7 +92,7 @@ sign (Secret secret) { typ, cty, alg, kid } { iss, sub, aud, exp, nbf, iat, jti,
       )
 
 -- Utility function used to automatically convert any foreign value into a token
-foreignToToken :: forall a s. Decode a => Foreign -> Either (NonEmptyList String) (Token a s)
+foreignToToken :: forall r l s. Decodable r l => Foreign -> Either (NonEmptyList String) (Token r s)
 foreignToToken value =
   { headers: _, claims: _ }
     <$> (map renderForeignError `lmap` headers value)
@@ -99,10 +100,10 @@ foreignToToken value =
 
 foreign import _decode :: Fn3 (Foreign -> Maybe Foreign) (Maybe Foreign) String (Maybe Foreign)
 
-decode :: forall a. Decode a => String -> Either (NonEmptyList String) (Token a Unverified)
+decode :: forall r l. Decodable r l => String -> Either (NonEmptyList String) (Token r Unverified)
 decode s = (note (singleton "Couldn't decode token") $ runFn3 _decode Just Nothing s) >>= foreignToToken
 
 foreign import _verify :: Fn4 (Foreign -> Maybe Foreign) (Maybe Foreign) String String (Maybe Foreign)
 
-verify :: forall a. Decode a => Secret -> String -> Either (NonEmptyList String) (Token a Verified)
+verify :: forall r l. Decodable r l => Secret -> String -> Either (NonEmptyList String) (Token r Verified)
 verify (Secret secret) s = (note (singleton "Couldn't verify token") $ runFn4 _verify Just Nothing secret s) >>= foreignToToken

--- a/src/Node/Options.purs
+++ b/src/Node/Options.purs
@@ -4,9 +4,10 @@ import Data.Either (Either)
 import Data.Functor.Contravariant (cmap)
 import Data.Maybe (Maybe)
 import Data.Options (Option, opt, optional)
-import Foreign.Generic (class Encode, Foreign, encode)
+import Foreign.Generic (Foreign, encode)
 import Prelude (($), (<<<))
 import Types (Algorithm, EitherWrapper(..), NumericDate, Typ)
+import GenericRecord (class Encodable)
 
 foreign import data SignOptions :: Type
 
@@ -56,5 +57,5 @@ nbf = optional $ cmap encode $ opt "nbf"
 exp :: Option PayloadOptions (Maybe NumericDate)
 exp = optional $ cmap encode $ opt "exp"
 
-unregistered :: forall a. Encode a => Option PayloadOptions (Maybe a)
+unregistered :: forall r l. Encodable r l => Option PayloadOptions (Maybe (Record r))
 unregistered = optional $ cmap encode $ opt "unregistered"

--- a/src/Node/Types.purs
+++ b/src/Node/Types.purs
@@ -16,7 +16,7 @@ import Effect.Aff (Milliseconds(..))
 import Foreign (ForeignError(..), readArray, readNumber, readString)
 import Foreign.Generic (class Decode, class Encode, encode)
 import Foreign.Generic.EnumEncoding (defaultGenericEnumOptions, genericDecodeEnum, genericEncodeEnum)
-import Prelude (class Eq, class Ord, class Show, Void, pure, show, ($), (*), (/), (<<<), (=<<), (>=>), (>>>))
+import Prelude (class Eq, class Ord, class Show, pure, show, ($), (*), (/), (<<<), (=<<), (>=>), (>>>))
 
 newtype EitherWrapper a b
   = EitherWrapper (Either a b)
@@ -43,7 +43,6 @@ derive instance eqNumericDate :: Eq NumericDate
 
 derive instance ordNumericDate :: Ord NumericDate
 
--- TODO: Drop this instance when possible
 instance showNumericDate :: Show NumericDate where
   show = unwrap >>> show
 
@@ -75,7 +74,6 @@ derive instance genericAlgorithm :: Generic Algorithm _
 
 derive instance eqAlgorithm :: Eq Algorithm
 
--- TODO: Drop this instance when possible
 instance showAlgorithm :: Show Algorithm where
   show = genericShow
 
@@ -92,7 +90,6 @@ derive instance genericTyp :: Generic Typ _
 
 derive instance eqTyp :: Eq Typ
 
--- TODO: Drop this instance when possible
 instance showTyp :: Show Typ where
   show = genericShow
 
@@ -112,7 +109,7 @@ type JOSEHeaders
 defaultHeaders :: JOSEHeaders
 defaultHeaders = { typ: JWT, cty: Nothing, alg: HS256, kid: Nothing }
 
-type Claims a
+type Claims r
   = { iss :: Maybe String
     , sub :: Maybe String
     , aud :: Maybe (Either String (Array String))
@@ -120,7 +117,7 @@ type Claims a
     , nbf :: Maybe NumericDate
     , iat :: Maybe NumericDate
     , jti :: Maybe String
-    , unregistered :: Maybe a
+    , unregistered :: Maybe (Record r)
     }
 
 data Verified
@@ -132,7 +129,7 @@ type Token a s
     , claims :: Claims a
     }
 
-defaultClaims :: Claims Void
+defaultClaims :: Claims ()
 defaultClaims =
   { iss: Nothing
   , sub: Nothing


### PR DESCRIPTION
Prepare the work to flatten claims in token, unregistered must be a record now.

---

I didn't remove the show instances since they could be useful, but made sure they're not used for encoding options to foreign.