### PR TITLE
Flatten unregistered claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,37 +26,45 @@ sign
 
 By default, some values will be set for you: `alg` will be `HS256`, `typ` equals `JWT`, and the `iat` field will be set to the creation timestamp. You _can_ override any for the above by providing the value explicitely.
 
-You can also provide an `unregistered` claim, that will contain literally any [encodable](https://pursuit.purescript.org/packages/purescript-foreign-generic/10.0.0/docs/Foreign.Generic.Class#t:Encode) data:
+You can also provide an `unregisteredClaims` record, each values of that record must be [encodable](https://pursuit.purescript.org/packages/purescript-foreign-generic/10.0.0/docs/Foreign.Generic.Class#t:Encode):
 
 ```purs
 sign
   (Secret "my-super-secret-key")
   defaultHeaders
-  (defaultClaims { unregistered = unregisteredClaim "Foo" } )
+  (defaultClaims { unregisteredClaims = Just { foo: "bar" } )
 ```
 
 ### Decode
 
-If decode succeeds, it will return a `Token Unverified` you can read the headers and claims from it:
+If decode succeeds, it will return a `Token r Unverified` where `r` is the row type of the `unregisteredClaims` record. You can read the headers and claims as follow:
 
 ```purs
 decodedHeaders :: String -> Maybe JOSEHeaders
-decodedHeaders token = decode token >>= hush <<< headers
+decodedHeaders token = hush $ decode' token <#> _.headers
 
-decodedClaims :: String -> Maybe Claims
-decodedClaims token = decode token >>= hush <<< claims
+decodedClaims :: String -> Maybe (Claims ())
+decodedClaims token = hush $ decode' token <#> _.claims
+
+decodedClaims' :: String -> Maybe (Claims ( foo :: String ))
+decodedClaims' token = hush $ decode token <#> _.claims
 ```
+
+Notice that when decoding claims with some explicit unregistered claims, said claims must be of the expected type at runtime.
 
 ### Verify
 
-If verify succeeds, it will return a `Token Verified` you can read the headers and claims from it:
+If verify succeeds, it will return a `Token Verified` you can read the headers and claims this way:
 
 ```purs
 verifiedHeaders :: String -> Maybe JOSEHeaders
-verifiedHeaders token = verify (Secret "my-super-secret-key") token >>= hush <<< headers
+verifiedHeaders token = hush $ verify' (Secret "my-super-secret-key") token <#> _.headers
 
-verifiedClaims :: String -> Maybe Claims
-verifiedClaims token = verify (Secret "my-super-secret-key") token >>= hush <<< claims
+verifiedClaims :: String -> Maybe (Claims ())
+verifiedClaims token = hush $ verify' (Secret "my-super-secret-key") token <#> _.claims
+
+verifiedClaims' :: String -> Maybe (Claims ( foo :: String ))
+verifiedClaims' token = hush $ verify (Secret "my-super-secret-key") token <#> _.claims
 ```
 
 ## Documentation

--- a/src/Node/Jwt.js
+++ b/src/Node/Jwt.js
@@ -1,31 +1,65 @@
-var jwt = require("jsonwebtoken");
+const jwt = require("jsonwebtoken");
 
-exports._decode = function decode(just, nothing, token) {
+const registeredClaimsKeys = ["iss", "sub", "aud", "exp", "nbf", "iat", "jti"];
+
+// TODO: Remove this when https://github.com/erikd/language-javascript/pull/118 is merged
+const partitionClaims = (claims) =>
+  Object.entries(claims).reduce(
+    ([registered, unregistered], [key, value]) => {
+      const claim = { [key]: value };
+
+      return registeredClaimsKeys.includes(key)
+        ? [Object.assign({}, registered, claim), unregistered]
+        : [registered, Object.assign({}, unregistered || {}, claim)];
+    },
+    [{}, undefined]
+  );
+
+const normalizeClaims = ({ header, payload, signature }, just, nothing) => {
   try {
-    const decodedToken = jwt.decode(token, { complete: true, json: false });
+    const [registeredClaims, unregisteredClaims] = partitionClaims(payload);
 
-    return decodedToken ? just(decodedToken) : nothing;
-  } catch (error) {
-    return nothing;
-  }
-};
-
-exports._verify = function verify(just, nothing, secret, token) {
-  try {
-    const verifiedToken = jwt.verify(token, secret, {
-      complete: true,
-      json: false,
+    return just({
+      header,
+      payload: Object.assign({}, registeredClaims, { unregisteredClaims }),
+      signature,
     });
-
-    return verifiedToken ? just(verifiedToken) : nothing;
-  } catch (error) {
+  } catch (_) {
     return nothing;
   }
 };
 
-exports._sign = function sign(payload, secret, options) {
+exports._decode = (just, nothing, token) => {
+  try {
+    return normalizeClaims(
+      jwt.decode(token, { complete: true, json: false }),
+      just,
+      nothing
+    );
+  } catch (_) {
+    return nothing;
+  }
+};
+
+exports._verify = (just, nothing, token, secret) => {
+  try {
+    return normalizeClaims(
+      jwt.verify(token, secret, { complete: true, json: false }),
+      just,
+      nothing
+    );
+  } catch (_) {
+    return nothing;
+  }
+};
+
+exports._sign = (payload, unregisteredClaims, secret, options) => {
+  const fullPayload = unregisteredClaims
+    ? Object.assign({}, payload, unregisteredClaims)
+    : payload;
+
   return new Promise(function (resolve, reject) {
-    jwt.sign(payload, secret, options, function (error, token) {
+    jwt.sign(fullPayload, secret, options, function (error, token) {
       if (error) {
         return reject(error);
       }

--- a/src/Node/Options.purs
+++ b/src/Node/Options.purs
@@ -7,7 +7,6 @@ import Data.Options (Option, opt, optional)
 import Foreign.Generic (Foreign, encode)
 import Prelude (($), (<<<))
 import Types (Algorithm, EitherWrapper(..), NumericDate, Typ)
-import GenericRecord (class Encodable)
 
 foreign import data SignOptions :: Type
 
@@ -56,6 +55,3 @@ nbf = optional $ cmap encode $ opt "nbf"
 
 exp :: Option PayloadOptions (Maybe NumericDate)
 exp = optional $ cmap encode $ opt "exp"
-
-unregistered :: forall r l. Encodable r l => Option PayloadOptions (Maybe (Record r))
-unregistered = optional $ cmap encode $ opt "unregistered"

--- a/src/Node/Types.purs
+++ b/src/Node/Types.purs
@@ -117,7 +117,7 @@ type Claims r
     , nbf :: Maybe NumericDate
     , iat :: Maybe NumericDate
     , jti :: Maybe String
-    , unregistered :: Maybe (Record r)
+    , unregisteredClaims :: Maybe (Record r)
     }
 
 data Verified
@@ -138,7 +138,7 @@ defaultClaims =
   , nbf: Nothing
   , iat: Nothing
   , jti: Nothing
-  , unregistered: Nothing
+  , unregisteredClaims: Nothing
   }
 
 newtype Secret


### PR DESCRIPTION
Unregistered claims will now get inserted at the top level, and not under the "unregistered" attribute anymore. I had to handle the flatten/normalize logic in JS, and since object spread is not yet supported in PureScript's JavaScript (https://github.com/erikd/language-javascript/pull/118) the code is a bit verbose. Once the above pr is merged, the code should be way cleaner.